### PR TITLE
Versión de eliminar UC 

### DIFF
--- a/docs/OpenAPI.yaml
+++ b/docs/OpenAPI.yaml
@@ -2763,8 +2763,9 @@ paths:
     delete:
       tags:
         - Usuario-Colecciones
-      summary: Eliminar relacion usuario-coleccion
-      description: Elimina una relacion entre usuario y coleccion
+      summary: Eliminar relacion usuario-coleccion (1)
+      deprecated: true
+      description: U sar DELETE /usuario-colecciones/v2/{id}. Elimina una relacion entre usuario y coleccion pero los items en relacion con la coleccion no se eliminan
       parameters:
         - name: id
           in: path
@@ -2777,6 +2778,54 @@ paths:
       responses:
         '204':
           description: Relacion eliminada exitosamente
+        '404':
+          description: Relacion no encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorRespuesta'
+              example:
+                statusCode: 404
+                message:Usuario-coleccion con ID: 999 no encontrado
+                errors: { }
+        '403':
+          description: Acceso denegado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorRespuesta'
+              example:
+                statusCode: 403
+                message: No tienes permisos para realizar esta acción
+                errors: { }
+        '500':
+          description: Error interno del servidor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorRespuesta'
+              example:
+                statusCode: 500
+                message: Error interno del servidor
+                errors: { }
+  /usuario-colecciones/v2/{id}:
+    delete:
+      tags:
+        - Usuario-Colecciones
+      summary: Eliminar relacion usuario-coleccion e items
+      description: Elimina una relacion entre usuario y coleccion y tambien limpia los items de la relacion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID de la relacion
+          schema:
+            type: integer
+            format: int64
+          example: 1
+      responses:
+        '204':
+          description: Relacion e items eliminada exitosamente
         '404':
           description: Relacion no encontrada
           content:

--- a/src/main/java/com/svalero/fancollector/controller/UsuarioColeccionController.java
+++ b/src/main/java/com/svalero/fancollector/controller/UsuarioColeccionController.java
@@ -5,6 +5,7 @@ import com.svalero.fancollector.dto.UsuarioColeccionOutDTO;
 import com.svalero.fancollector.dto.UsuarioColeccionPutDTO;
 import com.svalero.fancollector.dto.patches.UsuarioColeccionFavoritaDTO;
 import com.svalero.fancollector.dto.patches.UsuarioColeccionVisibleDTO;
+import com.svalero.fancollector.exception.domain.UsuarioColeccionNoEncontradoException;
 import com.svalero.fancollector.security.auth.SecurityUtils;
 import com.svalero.fancollector.service.UsuarioColeccionService;
 import jakarta.validation.Valid;
@@ -98,14 +99,22 @@ public class UsuarioColeccionController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> eliminar(
+    public ResponseEntity<Void> eliminar(@PathVariable Long id)
+            throws UsuarioColeccionNoEncontradoException {
+
+        usuarioColeccionService.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("v2/{id}")
+    public ResponseEntity<Void> eliminarV2(
             @PathVariable Long id,
             Authentication authentication) {
         String email = SecurityUtils.email(authentication);
         boolean esAdmin = SecurityUtils.isAdmin(authentication);
         boolean esMods = SecurityUtils.isMods(authentication);
 
-        usuarioColeccionService.eliminar(id, email, esAdmin, esMods);
+        usuarioColeccionService.eliminarV2(id, email, esAdmin, esMods);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/svalero/fancollector/service/UsuarioColeccionService.java
+++ b/src/main/java/com/svalero/fancollector/service/UsuarioColeccionService.java
@@ -18,7 +18,9 @@ public interface UsuarioColeccionService {
 
     UsuarioColeccionOutDTO actualizar(Long id, UsuarioColeccionPutDTO dto, String emailUsuario, boolean esAdmin, boolean esMods);
 
-    void eliminar(Long id, String emailUsuario, boolean esAdmin, boolean esMods);
+    void eliminar(Long id);
+
+    void eliminarV2(Long id, String emailUsuario, boolean esAdmin, boolean esMods);
 
     UsuarioColeccionOutDTO actualizarFavorita(Long id, UsuarioColeccionFavoritaDTO dto, String emailUsuario, boolean esAdmin, boolean esMods);
 

--- a/src/main/java/com/svalero/fancollector/service/UsuarioColeccionServiceImpl.java
+++ b/src/main/java/com/svalero/fancollector/service/UsuarioColeccionServiceImpl.java
@@ -167,9 +167,19 @@ public class UsuarioColeccionServiceImpl implements UsuarioColeccionService {
         return modelMapper.map(usuarioColeccionRepository.save(uc),UsuarioColeccionOutDTO.class);
     }
 
+    @Override
+    public void eliminar(Long id)
+            throws UsuarioColeccionNoEncontradoException {
+
+        UsuarioColeccion uc = usuarioColeccionRepository.findById(id)
+                .orElseThrow(() -> new UsuarioColeccionNoEncontradoException(id));
+
+        usuarioColeccionRepository.delete(uc);
+    }
+
     @Transactional
     @Override
-    public void eliminar(Long id, String emailUsuario, boolean esAdmin, boolean esMods) {
+    public void eliminarV2(Long id, String emailUsuario, boolean esAdmin, boolean esMods) {
         UsuarioColeccion uc = usuarioColeccionRepository.findById(id)
                 .orElseThrow(() -> new UsuarioColeccionNoEncontradoException(id));
         Usuario usuarioActual = currentUserResolver.usuarioActual(emailUsuario);

--- a/src/test/java/com/svalero/fancollector/controller/UsuarioColeccionControllerTest.java
+++ b/src/test/java/com/svalero/fancollector/controller/UsuarioColeccionControllerTest.java
@@ -321,6 +321,7 @@ public class UsuarioColeccionControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    // v1 eliminar
     @Test
     public void eliminarUsuarioColeccion_existente_devuelve204() throws Exception {
         mockMvc.perform(delete("/usuario-colecciones/1")
@@ -331,7 +332,25 @@ public class UsuarioColeccionControllerTest {
     @Test
     public void eliminarUsuarioColeccion_noExiste_devuelve404() throws Exception {
         doThrow(new UsuarioColeccionNoEncontradoException(1L))
-                .when(usuarioColeccionService).eliminar(eq(1L),anyString(),anyBoolean(),anyBoolean());
+                .when(usuarioColeccionService).eliminar(eq(1L));
+
+        mockMvc.perform(delete("/usuario-colecciones/1")
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    //v2 eliminar
+    @Test
+    public void eliminarUsuarioColeccionV2_existente_devuelve204() throws Exception {
+        mockMvc.perform(delete("/usuario-colecciones/1")
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void eliminarUsuarioColeccionV2_noExiste_devuelve404() throws Exception {
+        doThrow(new UsuarioColeccionNoEncontradoException(1L))
+                .when(usuarioColeccionService).eliminarV2(eq(1L),anyString(),anyBoolean(),anyBoolean());
 
         mockMvc.perform(delete("/usuario-colecciones/1")
                         .with(csrf()))

--- a/src/test/java/com/svalero/fancollector/service/UsuarioColeccionServiceTest.java
+++ b/src/test/java/com/svalero/fancollector/service/UsuarioColeccionServiceTest.java
@@ -381,8 +381,33 @@ public class UsuarioColeccionServiceTest {
         verify(usuarioColeccionRepository, never()).save(any(UsuarioColeccion.class));
     }
 
+    // V1 - ELIMINAR
     @Test
-    public void eliminar_existente_eliminaRelacionYSusItems() {
+    public void eliminar_existente_soloEliminaRelacion() {
+        when(usuarioColeccionRepository.findById(1L)).thenReturn(Optional.of(new UsuarioColeccion()));
+
+        usuarioColeccionService.eliminar(1L);
+
+        verify(usuarioColeccionRepository, times(1)).findById(1L);
+        verify(usuarioItemRepository, never()).deleteByUsuario_IdAndColeccion_Id(any(), any());
+        verify(usuarioColeccionRepository, times(1)).delete(any(UsuarioColeccion.class));
+    }
+
+    @Test
+    public void eliminar_noExiste_lanzaUsuarioColeccionNoEncontradoException() {
+        when(usuarioColeccionRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(UsuarioColeccionNoEncontradoException.class, () ->
+                usuarioColeccionService.eliminar(999L)
+        );
+
+        verify(usuarioColeccionRepository, times(1)).findById(999L);
+        verify(usuarioColeccionRepository, never()).delete(any(UsuarioColeccion.class));
+    }
+
+    // V2 - ELIMINAR
+    @Test
+    public void eliminarV2_existente_eliminaRelacionYSusItems() {
         boolean esAdmin = true;
         boolean esMods = false;
 
@@ -401,7 +426,7 @@ public class UsuarioColeccionServiceTest {
         when(usuarioColeccionRepository.findById(1L)).thenReturn(Optional.of(uc));
         when(currentUserResolver.usuarioActual(EMAIL)).thenReturn(usuario);
 
-        usuarioColeccionService.eliminar(1L, EMAIL, esAdmin, esMods);
+        usuarioColeccionService.eliminarV2(1L, EMAIL, esAdmin, esMods);
 
         verify(usuarioColeccionRepository, times(1)).findById(1L);
         verify(usuarioItemRepository, times(1))
@@ -410,14 +435,14 @@ public class UsuarioColeccionServiceTest {
     }
 
     @Test
-    public void eliminar_noExiste_lanzaUsuarioColeccionNoEncontradoException() {
+    public void eliminarV2_noExiste_lanzaUsuarioColeccionNoEncontradoException() {
         boolean esAdmin = true;
         boolean esMods = false;
 
         when(usuarioColeccionRepository.findById(999L)).thenReturn(Optional.empty());
 
         assertThrows(UsuarioColeccionNoEncontradoException.class, () ->
-                usuarioColeccionService.eliminar(999L, EMAIL, esAdmin, esMods)
+                usuarioColeccionService.eliminarV2(999L, EMAIL, esAdmin, esMods)
         );
 
         verify(usuarioColeccionRepository, times(1)).findById(999L);


### PR DESCRIPTION
Se añade deleteByUsuario_IdAndColeccion_Id en UsuarioItemRepository para que Spring genere el SQL de borrado

En el método de eliminar de UCServiceImpl se añade@Transactional para que las dos operaciones (borrar los UI+ borrar el UC) se ejecuten juntas

Mientras se mantiene el eliminar original 